### PR TITLE
Implemented length.out for 2 rand types

### DIFF
--- a/R/basefunctions.R
+++ b/R/basefunctions.R
@@ -6,7 +6,11 @@
 #' @param cols columns of dataframe that should be selected to be resampled/shuffled. Defaults for all columns.
 #' @param replace (logical) should the data be permuted (FALSE) or resampled with replacement (TRUE) ?
 #' @param stratum factor or integer vector that separates data in groups or strata. Randomizations will be performed within each level of the stratum. Needs at least two observations in each level. Default is a single-level stratum.
-#' 
+#' @param length.out (integer) specifies the size of the resulting dataset. 
+#' For columns_as_units, a data.frame with length.out columns will be returned, and for
+#' rows_as_units, a data.frame with length.out rows will be returned.
+#' Note that if length.out is larger than the relevant dimension, \code{replace} must also be specified.
+
 #' @section Details:
 #' 
 #' Each function performs as close as possible the corresponding options in Resampling Stats add-in for Excel
@@ -28,8 +32,10 @@
 #' All functions assemble the randomized values in a dataframe
 #' of the same configuration of the original. Columns that
 #' were not selected to be randomized with argument \code{cols} are then
-#' bound to the resulting dataframe.
+#' bound to the resulting dataframe. The order and names of the rows and columns are preserved, except if \code{length.out}
+#' is specified. In this case, the randomized rows/columns may be shifted to the end of the table.
 #'
+#' When both \code{stratum} and \code{length.out} are used, the function will try to keep the proportion of each strata close to the original.
 #'
 #' @return a dataframe with the same structure of those input in \code{dataframe} with values randomized accordingly.
 #' 
@@ -40,6 +46,19 @@
 
 #' @name basefunctions
 NULL
+
+# Helper function to calculate a distribution of sampling lengths within stratums, for when both stratum and length.out are specified
+rlength <- function (stratum, length.out) {
+	ust <- unique(stratum)
+	if(is.null(length.out)) return(sapply(ust, function(i) sum(stratum==i)))
+	tmp <- length.out * sapply(ust, function(i) sum(stratum==i)) / length(stratum)
+	tmp <- round(tmp)
+	if (sum(tmp) != length.out) {# one stratum is chosen at random to fix the rounding error
+		chosen <- sample(lenght(ust), 1)
+		tmp[ chosen ] <- length.out - sum(tmp[-chosen])
+	}
+    return(tmp)
+}
 
 #' @rdname basefunctions
 #' @export
@@ -75,20 +94,24 @@ normal_rand <- function(dataframe, cols=1:ncol(dataframe), stratum=rep(1,nrow(da
 
 #' @rdname basefunctions
 #' @export
-rows_as_units <- function(dataframe, stratum=rep(1,nrow(dataframe)), replace = FALSE){
+rows_as_units <- function(dataframe, stratum=rep(1,nrow(dataframe)), replace = FALSE, length.out=NULL){
     if(class(dataframe)!="data.frame") stop ("the 1st argument is not of class 'data.frame'")
     ust=unique(stratum)
+    rsize <- rlength(stratum, length.out)
     ind=c()
     for(i in ust){
-        ind<-c(ind, sample(which(stratum==i), replace=replace))
+        ind<-c(ind, sample(which(stratum==i), size=rsize[which(ust==i)], replace=replace))
     }
     dataframe[ind,]
 }
 
 #' @rdname basefunctions
 #' @export
-columns_as_units <- function(dataframe, cols=1:ncol(dataframe), replace = FALSE){
+columns_as_units <- function(dataframe, cols=1:ncol(dataframe), replace = FALSE, length.out=NULL){
     if(class(dataframe)!="data.frame") stop ("the 1st argument is not of class 'data.frame'")
-    dataframe[,cols] <- dataframe[,sample(cols, replace=replace)]
-        return(dataframe)
+    if (missing(length.out))
+      dataframe[,cols] <- dataframe[,sample(cols, replace=replace)]
+    else
+      dataframe <- cbind(dataframe[,-cols], dataframe[,sample(cols, size=length.out, replace=replace)])
+    return(dataframe)
 }

--- a/man/basefunctions.Rd
+++ b/man/basefunctions.Rd
@@ -17,9 +17,11 @@ within_columns(dataframe, cols = 1:ncol(dataframe), stratum = rep(1,
 normal_rand(dataframe, cols = 1:ncol(dataframe), stratum = rep(1,
   nrow(dataframe)), replace = FALSE)
 
-rows_as_units(dataframe, stratum = rep(1, nrow(dataframe)), replace = FALSE)
+rows_as_units(dataframe, stratum = rep(1, nrow(dataframe)), replace = FALSE,
+  length.out = NULL)
 
-columns_as_units(dataframe, cols = 1:ncol(dataframe), replace = FALSE)
+columns_as_units(dataframe, cols = 1:ncol(dataframe), replace = FALSE,
+  length.out = NULL)
 }
 \arguments{
 \item{dataframe}{a dataframe with the data to be shuffled or resampled.}
@@ -29,6 +31,11 @@ columns_as_units(dataframe, cols = 1:ncol(dataframe), replace = FALSE)
 \item{replace}{(logical) should the data be permuted (FALSE) or resampled with replacement (TRUE) ?}
 
 \item{stratum}{factor or integer vector that separates data in groups or strata. Randomizations will be performed within each level of the stratum. Needs at least two observations in each level. Default is a single-level stratum.}
+
+\item{length.out}{(integer) specifies the size of the resulting dataset.
+For columns_as_units, a data.frame with length.out columns will be returned, and for
+rows_as_units, a data.frame with length.out rows will be returned.
+Note that if length.out is larger than the relevant dimension, \code{replace} must also be specified.}
 }
 \value{
 a dataframe with the same structure of those input in \code{dataframe} with values randomized accordingly.
@@ -58,7 +65,10 @@ Only the placement of rows and columns in the dataframe change. The position of 
 All functions assemble the randomized values in a dataframe
 of the same configuration of the original. Columns that
 were not selected to be randomized with argument \code{cols} are then
-bound to the resulting dataframe.
+bound to the resulting dataframe. The order and names of the rows and columns are preserved, except if \code{length.out}
+is specified. In this case, the randomized rows/columns may be shifted to the end of the table.
+
+When both \code{stratum} and \code{length.out} are used, the function will try to keep the proportion of each strata close to the original.
 }
 
 \section{References}{


### PR DESCRIPTION
Implemented length.out for two of the randomization types, please test if this behaves as intended.

I don't think the other types of randomization can have this feature together with `cols` - we can implement it in way that the function stops with error if both cols and length.out are specified?

Also, I don't think this should be included in the interfaces.
