### PR TITLE
Fixing errors on within_rows and within_columns when length(cols)=1

### DIFF
--- a/R/basefunctions.R
+++ b/R/basefunctions.R
@@ -66,6 +66,7 @@ rlength <- function (stratum, length.out) {
 #' @export
 within_rows <- function(dataframe, cols=1:ncol(dataframe), replace=FALSE, FUN=base::sample){
     if(class(dataframe)!="data.frame") stop ("the 1st argument is not of class 'data.frame'")
+    if(length(cols) < 2) stop ("You need to specify at least 2 columns for within_rows")
     dataframe[,cols] <- as.data.frame(t(apply(dataframe[,cols], 1, FUN, replace=replace)))
     return(dataframe)   
 }
@@ -77,9 +78,14 @@ within_columns <- function(dataframe, cols=1:ncol(dataframe), stratum=rep(1,nrow
     if(class(dataframe)!="data.frame") stop ("the 1st argument is not of class 'data.frame'")
     ust=unique(stratum)
     #dfs=dataframe[,cols]
-    for(i in ust){
-        dataframe[stratum == i, cols]<- apply(dataframe[stratum == i,cols], 2, FUN, replace=replace)
-    }
+    if (length(cols) > 1)  
+        for(i in ust){
+            dataframe[stratum == i, cols]<- apply(dataframe[stratum == i,cols], 2, FUN, replace=replace)
+        }
+    else
+        for(i in ust){
+            dataframe[stratum == i, cols]<- FUN(dataframe[stratum == i,cols], replace=replace)
+        }
     return(dataframe)   
 }
 


### PR DESCRIPTION
This fixes the error reported on the interface for `within_columns`
