### PR TITLE
Renoves redundant argument in splot

### DIFF
--- a/R/plotfunctions.R
+++ b/R/plotfunctions.R
@@ -4,28 +4,26 @@
 #' @param p1,p2 vectors of paired values (numerical vectors)
 #' @param highlight should positive and negative differences within pairs highlighted with different colors? Logical
 #' @param col.dif color vector if \code{highlight = TRUE}
-#' @param groups.names labels for the groups names; numeric or character vector of length two.
-#' @param ... further arguments to be passed to \code{plot} function.
+#' @param ... further arguments to be passed to plotting function (\code{stripchart}).
 #'
 #' @export
 #' @import graphics
 #' @import stats
-splot <- function(p1, p2, highlight = TRUE, col.dif = c("black","grey"), groups.names=c(1,2), ...){
+splot <- function(p1, p2, highlight = TRUE, col.dif = c("black","grey"), ...){
   dots <- list(...)
   if(!"pch"%in%names(dots)) dots$pch=19
   if(!"xlim"%in%names(dots)) dots$xlim=c(0.8,2.2)
-  grupo <- rep(groups.names,each=length(p1))
   if(highlight){
     diferencas <- p1-p2
-    do.call(stripchart, c(list(x=as.formula("c(p1[diferencas>0],p2[diferencas>0])~rep(groups.names,each=length(p1[diferencas>0]))"),
-                               vertical =TRUE,col=col.dif[1], ylim=range(c(p1,p2))),dots))
-    do.call(stripchart, list(x=as.formula("c(p1[diferencas<=0],p2[diferencas<=0])~rep(groups.names,each=length(p1[diferencas<=0]))"),
+    do.call(stripchart, c(list(x=as.formula("c(p1[diferencas>0],p2[diferencas>0])~rep(1:2,each=length(p1[diferencas>0]))"),
+                               vertical = TRUE, col = col.dif[1], ylim = range(c(p1,p2))), dots))
+    do.call(stripchart, list(x=as.formula("c(p1[diferencas<=0],p2[diferencas<=0])~rep(1:2,each=length(p1[diferencas<=0]))"),
                                vertical =TRUE,col=col.dif[2], pch=dots$pch, add=TRUE))
-    segments(x0=1,y0=p1[diferencas>0],x1=2,y1=p2[diferencas>0],col=col.dif[1])
-    segments(x0=1,y0=p1[diferencas<=0],x1=2,y1=p2[diferencas<=0], col=col.dif[2])
+    segments(x0=1, y0=p1[diferencas>0], x1=2, y1=p2[diferencas>0], col=col.dif[1])
+    segments(x0=1, y0=p1[diferencas<=0], x1=2, y1=p2[diferencas<=0], col=col.dif[2])
   }
   else{
-    do.call(stripchart, c(list(x=as.formula("c(p1,p2)~grupo"), vertical =TRUE),dots))
+    do.call(stripchart, c(list(x=as.formula("c(p1,p2)~rep(1:2,each=length(p1)"), vertical =TRUE),dots))
     segments(x0=1,y0=p1,x1=2,y1=p2)
   }
 }

--- a/man/splot.Rd
+++ b/man/splot.Rd
@@ -4,8 +4,7 @@
 \alias{splot}
 \title{Spaghetti plot}
 \usage{
-splot(p1, p2, highlight = TRUE, col.dif = c("black", "grey"),
-  groups.names = c(1, 2), ...)
+splot(p1, p2, highlight = TRUE, col.dif = c("black", "grey"), ...)
 }
 \arguments{
 \item{p1, p2}{vectors of paired values (numerical vectors)}
@@ -14,9 +13,7 @@ splot(p1, p2, highlight = TRUE, col.dif = c("black", "grey"),
 
 \item{col.dif}{color vector if \code{highlight = TRUE}}
 
-\item{groups.names}{labels for the groups names; numeric or character vector of length two.}
-
-\item{...}{further arguments to be passed to \code{plot} function.}
+\item{...}{further arguments to be passed to plotting function (\code{stripchart}).}
 }
 \description{
 Quick plot of paired differences, for exploratory purposes.

--- a/vignettes/RRR.Rmd
+++ b/vignettes/RRR.Rmd
@@ -208,7 +208,7 @@ seja maior, o que ocorreu:
 
 ```{r pairplot azteca, fig.cap = "Número de formigas recrutadas por extratos de folhas novas e velhas de embaúbas. Os extratos foram aplicados em pares de folhas próximas em embaúbas que tinham colônias de formigas. As linhas ligam folhas do mesmo par experimental."}
 splot(azteca$extract.new, azteca$extract.old,
-           groups.names=c("Folha nova","Folha velha"),
+           group.name=c("Folha nova","Folha velha"),
            ylab="N de formigas recrutadas",
            xlab="Tipo de extrato aplicado")
 ```

--- a/vignettes/RRRe.Rmd
+++ b/vignettes/RRRe.Rmd
@@ -195,7 +195,7 @@ Indeed this was the outcome of the experiment:
 
 ```{r pairplot azteca, fig.cap = "Number ants that were recruited by aqueous extracts of young and old leaves of *Cecropia* trees. The extracts were dropped in paired leaves of *Cecropia* trees that had colonies of *Azteca* ants. The lines link leaves of same experimental pair."}
 splot(azteca$extract.new, azteca$extract.old,
-           groups.names=c("Young leaves","Old leaves"),
+           group.name=c("Young leaves","Old leaves"),
            ylab="Number of recruited ants",
            xlab="Extract type")
 ```


### PR DESCRIPTION
`splot` argument `groups.names` is redundant with `stripchart` argument `group.name`. Also causes some bugs because sorting of factor levels in formula interface of stripchart. Removed.
